### PR TITLE
Fix growler icon output syntax

### DIFF
--- a/src/component/growler.jsx
+++ b/src/component/growler.jsx
@@ -12,7 +12,7 @@ const GrowlerComponent = ({growler, hideGrowler, message}) => {
 
   return (
     <div className={growlerClass} onClick={ (evt) => { evt.preventDefault(); hideGrowler(growler);} }>
-      <span className="icon {growler.icon}"></span>
+      <span className={`icon ${growler.icon}`}></span>
       { message }
     </div>
   );


### PR DESCRIPTION
Fixes variable name getting output in place of the icon

![image](https://cloud.githubusercontent.com/assets/753310/20763322/672ccb64-b6de-11e6-896e-d4c3a59f3485.png)
